### PR TITLE
Add travis-ci and coverage support + 2 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ sudo: false
 language: ruby
 rvm:
   - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
 before_install: gem install bundler
-script: "bundle exec rake"

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,11 @@ source "https://rubygems.org"
 gemspec
 
 group :development, :test do
-  gem "minitest"
-  gem "pry"
-  gem "rake"
-  gem "rubocop-checkstyle_formatter"
-  gem "test-unit"
+  gem 'coveralls'
+  gem 'minitest'
+  gem 'pry'
+  gem 'rake'
+  gem 'rubocop-checkstyle_formatter'
+  gem 'simplecov'
+  gem 'test-unit'
 end

--- a/test/rfauxfactory_test.rb
+++ b/test/rfauxfactory_test.rb
@@ -1,5 +1,5 @@
-require 'set'
 require "test_helper"
+require "set"
 
 class RFauxFactoryTest < Minitest::Test
   GENERATORS = %i[
@@ -29,6 +29,25 @@ class RFauxFactoryTest < Minitest::Test
   HTML_TAG_MIN_LENGTH = 2 * RFauxFactory::HTML_TAGS.map(&:length).min + 5 # '<></>'.length == 5
   def test_has_a_version_number
     refute_nil ::RFauxFactory::VERSION
+  end
+
+  def assert_letters_ranges(ranges = [])
+    assert !ranges.empty?
+    last_max_range = 0
+    ranges.each do |codepoint_range|
+      codepoint_range.is_a?(Range)
+      assert codepoint_range.max >= codepoint_range.min
+      assert codepoint_range.min > last_max_range
+      last_max_range = codepoint_range.max
+    end
+  end
+
+  def test_latin1_letters_ranges
+    assert_letters_ranges RFauxFactory::LATIN_LETTERS_RANGES
+  end
+
+  def test_unicode_letters_ranges
+    assert_letters_ranges RFauxFactory::UNICODE_LETTERS_RANGES
   end
 
   # Default string generated is longer than zero characters.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,17 @@
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
-require "rfauxfactory"
+if RUBY_VERSION > "2.5"
+  require 'simplecov'
+  require 'coveralls'
 
+  SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter,
+                          Coveralls::SimpleCov::Formatter]
+  SimpleCov.start do
+    minimum_coverage 70
+    maximum_coverage_drop 0.1
+    refuse_coverage_drop
+  end
+end
+
+$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+
+require "rfauxfactory"
 require "minitest/autorun"


### PR DESCRIPTION
```console
 wwtd
Ignoring: before_install, language, sudo
START rvm: 2.2
bundle install --quiet
bundle exec rake
Running RuboCop...
Inspecting 9 files
.........

9 files inspected, no offenses detected
Run options: --seed 57632

# Running:

......................

Finished in 0.002655s, 8284.9074 runs/s, 487303.1906 assertions/s.

22 runs, 1294 assertions, 0 failures, 0 errors, 0 skips
SUCCESS rvm: 2.2
START rvm: 2.3
bundle install --quiet
bundle exec rake
Running RuboCop...
Inspecting 9 files
.........

9 files inspected, no offenses detected
Run options: --seed 36362

# Running:

......................

Finished in 0.006467s, 3401.9049 runs/s, 200093.8616 assertions/s.

22 runs, 1294 assertions, 0 failures, 0 errors, 0 skips
SUCCESS rvm: 2.3
START rvm: 2.4
bundle install --quiet
bundle exec rake
Running RuboCop...
Inspecting 9 files
.........

9 files inspected, no offenses detected
Run options: --seed 41168

# Running:

......................

Finished in 0.002202s, 9993.1365 runs/s, 587778.1213 assertions/s.

22 runs, 1294 assertions, 0 failures, 0 errors, 0 skips
SUCCESS rvm: 2.4
START rvm: 2.5
bundle install --quiet
bundle exec rake
Running RuboCop...
Inspecting 9 files
.........

9 files inspected, no offenses detected
Run options: --seed 65321

# Running:

......................

Finished in 0.002347s, 9372.1591 runs/s, 551253.3588 assertions/s.

22 runs, 1294 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for Unit Tests to /home/dlezz/projects/RFauxFactory/coverage. 656 / 656 LOC (100.0%) covered.
[Coveralls] Outside the Travis environment, not sending data.
SUCCESS rvm: 2.5
rm -rf .bundle

Results:
SUCCESS rvm: 2.2
SUCCESS rvm: 2.3
SUCCESS rvm: 2.4
SUCCESS rvm: 2.5
```